### PR TITLE
Support most classicthesis options as #lang options

### DIFF
--- a/style.tex
+++ b/style.tex
@@ -18,10 +18,6 @@
 \newcommand{\Ssubmitdate}[1]{\newcommand{\myTime}{#1}}
 %% \newcommand{\myVersion}{Put data here} %% ditto
 
-\PassOptionsToPackage{eulerchapternumbers,%drafting,
-  pdfspacing,%floatperchapter,%linedheaders,%
-  eulermath,parts}{classicthesis}
-
 \newcounter{dummy} % necessary for correct hyperlinks (to index, bib, etc.)
 \newlength{\abcd} % for ab..z string length calculation
 \usepackage{textcomp} % fix warning with missing font shapes


### PR DESCRIPTION
TODO for future: decide what to do about float options. Maybe allow a font size option that takes an argument.

Note that this is backwards incompatible because it disables some previously baked in defaults (inconsistent with the defaults of the TeX package).
